### PR TITLE
Feature sorting

### DIFF
--- a/configs/codestyles/ProlificAndroid.xml
+++ b/configs/codestyles/ProlificAndroid.xml
@@ -45,6 +45,7 @@
   <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
   <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
   <option name="ALIGN_MULTILINE_FOR" value="false" />
+  <option name="ALIGN_GROUP_FIELD_DECLARATIONS" value="true" />
   <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
   <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
   <option name="CALL_PARAMETERS_WRAP" value="1" />
@@ -102,6 +103,9 @@
     <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
   </JavaCodeStyleSettings>
+  <Properties>
+    <option name="SPACES_AROUND_KEY_VALUE_DELIMITER" value="true" />
+  </Properties>
   <XML>
     <option name="XML_ALIGN_ATTRIBUTES" value="false" />
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -194,6 +198,9 @@
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
     <option name="TERNARY_OPERATION_WRAP" value="1" />
     <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+    <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+    <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
@@ -645,7 +652,21 @@
         <section>
           <rule>
             <match>
-              <OVERRIDDEN />
+              <AND>
+                <METHOD>true</METHOD>
+                <NAME>setUpViews</NAME>
+                <PUBLIC>true</PUBLIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <NAME>toBuilder</NAME>
+              </AND>
             </match>
           </rule>
         </section>
@@ -657,6 +678,20 @@
                 <OVERRIDDEN />
               </AND>
             </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <OVERRIDDEN />
+                <PROTECTED>true</PROTECTED>
+                <PUBLIC>true</PUBLIC>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
           </rule>
         </section>
         <section>
@@ -889,7 +924,28 @@
         <section>
           <rule>
             <match>
+              <AND>
+                <NAME>.*</NAME>
+                <XML_NAMESPACE>http://schemas.android.com/tools</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
               <NAME>style</NAME>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>fontPath</NAME>
+                <XML_ATTRIBUTE />
+              </AND>
             </match>
           </rule>
         </section>


### PR DESCRIPTION
Changelog:
* added rule to put `fontPath` at the end
* added rules for:
  * toBuilder: move to the top for autovalue classes
  * setUpViews: moving on top of all overriden methods but still after lifecycle methods
* code style now allows simple method, simple class and simple lambdas on a single line. This is not mandatory but optional
* properties values are now aligned in column
