### PR TITLE
Fix - XML Values Attributes -Chop down if long

### DIFF
--- a/configs/codestyles/ProlificAndroid.xml
+++ b/configs/codestyles/ProlificAndroid.xml
@@ -89,7 +89,7 @@
     </option>
     <option name="VALUE_RESOURCE_FILE_SETTINGS">
       <value>
-        <option name="WRAP_ATTRIBUTES" value="2" />
+        <option name="WRAP_ATTRIBUTES" value="4" />
       </value>
     </option>
     <option name="OTHER_SETTINGS">


### PR DESCRIPTION
- Chop values attributes only if long in xml

@prolificinteractive/android-devs 